### PR TITLE
Doctor: auto-fix common status/stage mismatches (WL-0MMMFYJTO0B4H4UV)

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -211,14 +211,21 @@ export default function register(ctx: PluginContext): void {
           // fall back to hard-coded default
         }
 
-        // Auto-fix: if an item is `completed` with stage `in_progress`, convert stage -> `in_review`.
-        // This handles a common mismatch where completed items retained an in-progress stage.
+        // Auto-fix rules for common incompatible status/stage combos
         for (const f of findings) {
           try {
             const ctx = (f && (f as any).context) || {};
+            // completed + (in_progress|intake_complete|idea) -> completed + in_review
             if (f.type === 'incompatible-status-stage' && ctx.status === 'completed' && (ctx.stage === 'in_progress' || ctx.stage === 'intake_complete' || ctx.stage === 'idea')) {
               const current = (f.proposedFix && typeof f.proposedFix === 'object') ? (f.proposedFix as Record<string, unknown>) : {};
               (f as any).proposedFix = Object.assign({}, current, { stage: 'in_review' });
+              (f as any).safe = true;
+            }
+
+            // deleted + in_progress -> deleted + done
+            if (f.type === 'incompatible-status-stage' && ctx.status === 'deleted' && ctx.stage === 'in_progress') {
+              const current = (f.proposedFix && typeof f.proposedFix === 'object') ? (f.proposedFix as Record<string, unknown>) : {};
+              (f as any).proposedFix = Object.assign({}, current, { stage: 'done' });
               (f as any).safe = true;
             }
           } catch (e) {


### PR DESCRIPTION
Summary

Apply safe auto-fixes in 'wl doctor --fix' for common status/stage mismatches:

- Convert completed + in_progress|intake_complete|idea -> completed + in_review
- Convert deleted + in_progress -> deleted + done

Changes

- Inline auto-fix logic in src/commands/doctor.ts to mark findings as safe and apply updates when --fix is passed.
- Existing interactive prompt and JSON output behavior preserved.

Testing

- Manual: run `wl doctor --fix` in your workspace to apply safe fixes; CLI will skip interactive prompts in JSON mode.

Related work item: WL-0MMMFYJTO0B4H4UV