### PR TITLE
WL-0MN7T49VD002SQ3T: Remove autoExport deprecation warning

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -15,8 +15,7 @@ const CONFIG_FILE = 'config.yaml';
 const CONFIG_DEFAULTS_FILE = 'config.defaults.yaml';
 const INIT_SEMAPHORE_FILE = 'initialized';
 
-// Track if autoExport deprecation warning has been shown to avoid spamming TUI
-let autoExportWarningShown = false;
+
 
 /**
  * Get the path to the config directory
@@ -187,15 +186,6 @@ export function loadConfig(): WorklogConfig | null {
   if (statusStageError) {
     console.error(statusStageError);
     return null;
-  }
-
-  // Warn about deprecated autoExport option (but don't fail)
-  // Only show warning once to avoid spamming TUI output
-  const rawConfig = config as any;
-  if (rawConfig?.autoExport !== undefined && !autoExportWarningShown) {
-    autoExportWarningShown = true;
-    // Write to stderr to avoid interfering with TUI stdout
-    process.stderr.write('Warning: autoExport config option is deprecated and will be ignored. Export functionality has been removed.\n');
   }
   
   return config;


### PR DESCRIPTION
## Summary
Removes the deprecated autoExport config option warning that was displayed when the export functionality was removed.

## Changes
- Removed  variable
- Removed warning message for deprecated autoExport config option

## Testing
Run  commands and verify no autoExport warning appears.